### PR TITLE
Add admin user setup and port mapping for Linkding

### DIFF
--- a/apps/linkding/config.json
+++ b/apps/linkding/config.json
@@ -12,7 +12,7 @@
     "data"
   ],
   "version": "1.40.0",
-  "tipi_version": 2,
+  "tipi_version": 1,
   "source": "https://github.com/sissbruecker/linkding",
   "exposable": true,
   "no_gui": false,

--- a/apps/linkding/config.json
+++ b/apps/linkding/config.json
@@ -11,8 +11,8 @@
   "categories": [
     "data"
   ],
-  "version": "latest",
-  "tipi_version": 1,
+  "version": "1.40.0",
+  "tipi_version": 2,
   "source": "https://github.com/sissbruecker/linkding",
   "exposable": true,
   "no_gui": false,

--- a/apps/linkding/config.json
+++ b/apps/linkding/config.json
@@ -2,7 +2,7 @@
   "id": "linkding",
   "available": true,
   "deprecated": false,
-  "port": 8656,
+  "port": 8666,
   "name": "linkding",
   "description": "linkding is a bookmark manager that you can host yourself. It's designed be to be minimal, fast, and easy to set up using Docker.",
   "short_desc": "linkding is a bookmark manager that you can host yourself. It's designed be to be minimal, fast, and easy to set up using Docker.",

--- a/apps/linkding/config.json
+++ b/apps/linkding/config.json
@@ -26,7 +26,29 @@
   ],
   "min_tipi_version": "0.0.0",
   "force_pull": false,
-  "form_fields": [],
+  "form_fields": [
+    {
+      "type": "text",
+      "label": "Admin Username",
+      "required": true,
+      "env_variable": "LD_SUPERUSER_NAME",
+      "hint": "The username for the Linkding admin account"
+    },
+    {
+      "type": "text",
+      "label": "Admin Email",
+      "required": true,
+      "env_variable": "LD_SUPERUSER_EMAIL",
+      "hint": "Email address for the Linkding admin (used for password recovery)"
+    },
+    {
+      "type": "password",
+      "label": "Admin Password",
+      "required": true,
+      "env_variable": "LD_SUPERUSER_PASSWORD",
+      "hint": "Password for the admin account (make it strong)"
+    }
+  ],
   "created_at": 1748104301,
   "updated_at": 1748104301
 }

--- a/apps/linkding/config.json
+++ b/apps/linkding/config.json
@@ -2,7 +2,7 @@
   "id": "linkding",
   "available": true,
   "deprecated": false,
-  "port": 9090,
+  "port": 8656,
   "name": "linkding",
   "description": "linkding is a bookmark manager that you can host yourself. It's designed be to be minimal, fast, and easy to set up using Docker.",
   "short_desc": "linkding is a bookmark manager that you can host yourself. It's designed be to be minimal, fast, and easy to set up using Docker.",

--- a/apps/linkding/docker-compose.json
+++ b/apps/linkding/docker-compose.json
@@ -6,13 +6,13 @@
       "isMain": true,
       "addPorts": [
         {
-          "hostPort": "9090",
+          "hostPort": "8656",
           "containerPort": "9090",
           "tcp": true,
           "udp": false
         }
       ],
-      "internalPort": "9090",
+      "internalPort": "8656",
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data",

--- a/apps/linkding/docker-compose.json
+++ b/apps/linkding/docker-compose.json
@@ -12,7 +12,7 @@
           "udp": false
         }
       ],
-      "internalPort": "8666",
+      "internalPort": "9090",
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data",

--- a/apps/linkding/docker-compose.json
+++ b/apps/linkding/docker-compose.json
@@ -13,6 +13,11 @@
         }
       ],
       "internalPort": "9090",
+      "environment": {
+        "LD_SUPERUSER_NAME": "${LD_SUPERUSER_NAME}",
+        "LD_SUPERUSER_PASSWORD": "${LD_SUPERUSER_PASSWORD}",
+        "LD_SUPERUSER_EMAIL": "${LD_SUPERUSER_EMAIL}"
+      },
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data",

--- a/apps/linkding/docker-compose.json
+++ b/apps/linkding/docker-compose.json
@@ -6,13 +6,13 @@
       "isMain": true,
       "addPorts": [
         {
-          "hostPort": "8656",
+          "hostPort": "8666",
           "containerPort": "9090",
           "tcp": true,
           "udp": false
         }
       ],
-      "internalPort": "8656",
+      "internalPort": "8666",
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data",

--- a/apps/linkding/docker-compose.json
+++ b/apps/linkding/docker-compose.json
@@ -2,7 +2,7 @@
   "services": [
     {
       "name": "linkding",
-      "image": "sissbruecker/linkding:latest",
+      "image": "sissbruecker/linkding:1.40.0",
       "isMain": true,
       "addPorts": [
         {


### PR DESCRIPTION
### Summary of Changes

1. **Added environment variables:**

   * `LD_SUPERUSER_NAME`
   * `LD_SUPERUSER_EMAIL`
   * `LD_SUPERUSER_PASSWORD`
     These variables enable automatic creation of the admin user on the container’s first startup.

2. **Added `form_fields` section:**

   * Allows setting the admin user credentials through the Runtipi installation UI.
   * All fields are required: admin username, email, and password.

3. **Port mapping updated:**

   * The internal port `9090` is mapped to external port `8666` to avoid port conflicts and provide external access.
